### PR TITLE
EQLegends: Add support for 'cleave' 'reave' and 'smite' for DPS parser

### DIFF
--- a/EQLogParser.Test/src/parsing/DamageLineParserTest.cs
+++ b/EQLogParser.Test/src/parsing/DamageLineParserTest.cs
@@ -112,6 +112,100 @@ namespace EQLogParserTest
     }
 
     [TestMethod]
+    public void TestMelee_Cleaves()
+    {
+      var record = ParseAction("Astralx cleaves Sontalak for 126225 points of damage. (Critical)");
+      Assert.IsNotNull(record);
+      Assert.AreEqual("Astralx", record.Attacker);
+      Assert.AreEqual("Sontalak", record.Defender);
+      Assert.AreEqual((uint)126225, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Cleaves", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+      Assert.IsTrue(LineModifiersParser.IsCrit(record.ModifiersMask));
+    }
+
+    [TestMethod]
+    public void TestMelee_Cleaves_NoModifiers()
+    {
+      var record = ParseAction("Useless cleaves an abyssal terror for 9022 points of damage.");
+      Assert.IsNotNull(record);
+      Assert.AreEqual("Useless", record.Attacker);
+      Assert.AreEqual("An abyssal terror", record.Defender);
+      Assert.AreEqual((uint)9022, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Cleaves", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+    }
+
+    [TestMethod]
+    public void TestMelee_Cleaves_LuckyCritical()
+    {
+      var record = ParseAction("You cleave Ogna, Artisan of War for 20581 points of damage. (Lucky Critical)");
+      Assert.IsNotNull(record);
+      Assert.AreEqual(ConfigUtil.PlayerName, record.Attacker);
+      Assert.AreEqual("Ogna, Artisan of War", record.Defender);
+      Assert.AreEqual((uint)20581, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Cleaves", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+      Assert.IsTrue(LineModifiersParser.IsCrit(record.ModifiersMask));
+      Assert.IsTrue(LineModifiersParser.IsLucky(record.ModifiersMask));
+    }
+
+    [TestMethod]
+    public void TestMelee_YouSmite_NoModifiers()
+    {
+      var record = ParseAction("You smite an abyssal terror for 9022 points of damage.");
+      Assert.IsNotNull(record);
+      Assert.AreEqual(ConfigUtil.PlayerName, record.Attacker);
+      Assert.AreEqual("An abyssal terror", record.Defender);
+      Assert.AreEqual((uint)9022, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Smites", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+    }
+
+    [TestMethod]
+    public void TestMelee_Smites_NoModifiers()
+    {
+      var record = ParseAction("Useless smites an abyssal terror for 9022 points of damage.");
+      Assert.IsNotNull(record);
+      Assert.AreEqual("Useless", record.Attacker);
+      Assert.AreEqual("An abyssal terror", record.Defender);
+      Assert.AreEqual((uint)9022, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Smites", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+    }
+
+    [TestMethod]
+    public void TestMelee_YouReave_NoModifiers()
+    {
+      var record = ParseAction("You reave an abyssal terror for 9022 points of damage.");
+      Assert.IsNotNull(record);
+      Assert.AreEqual(ConfigUtil.PlayerName, record.Attacker);
+      Assert.AreEqual("An abyssal terror", record.Defender);
+      Assert.AreEqual((uint)9022, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Reaves", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+    }
+
+    [TestMethod]
+    public void TestMelee_Reaves_NoModifiers()
+    {
+      var record = ParseAction("Useless reaves an abyssal terror for 9022 points of damage.");
+      Assert.IsNotNull(record);
+      Assert.AreEqual("Useless", record.Attacker);
+      Assert.AreEqual("An abyssal terror", record.Defender);
+      Assert.AreEqual((uint)9022, record.Total);
+      Assert.AreEqual(Labels.Melee, record.Type);
+      Assert.AreEqual("Reaves", record.SubType);
+      Assert.IsFalse(record.AttackerIsSpell);
+    }
+
+    [TestMethod]
     public void TestMelee_Pierces()
     {
       var record = ParseAction("Nniki pierces an ice giant for 101810 points of damage. (Critical)");

--- a/EQLogParser/src/parsing/ParserUtil.cs
+++ b/EQLogParser/src/parsing/ParserUtil.cs
@@ -189,6 +189,7 @@ namespace EQLogParser
         "backstab" => "backstabs",
         "bite" => "bites",
         "claw" => "claws",
+        "cleave" => "cleaves",
         "crush" => "crushes",
         "frenzy" => "frenzies",
         "gore" => "gores",
@@ -198,19 +199,21 @@ namespace EQLogParser
         "maul" => "mauls",
         "punch" => "punches",
         "pierce" => "pierces",
+        "reave" => "reaves",
         "rend" => "rends",
         "shoot" => "shoots",
         "slash" => "slashes",
         "slam" => "slams",
         "slice" => "slices",
         "smash" => "smashes",
+        "smite" => "smites",
         "stab" => "stabs",
         "sting" => "stings",
         "strike" => "strikes",
         "sweep" => "sweeps",
-        "bashes" or "backstabs" or "bites" or "claws" or "crushes" or "frenzies" or
-        "gores" or "hits" or "kicks" or "learns" or "mauls" or "punches" or "pierces" or
-        "rends" or "shoots" or "slashes" or "slams" or "slices" or "smashes" or "stabs" or
+        "bashes" or "backstabs" or "bites" or "claws" or "cleaves" or "crushes" or "frenzies" or
+        "gores" or "hits" or "kicks" or "learns" or "mauls" or "punches" or "pierces" or "reaves" or
+        "rends" or "shoots" or "slashes" or "slams" or "slices" or "smashes" or "smites" or "stabs" or
         "stings" or "strikes" or "sweeps" => word,
         _ => null
       };


### PR DESCRIPTION
- Adds a few new melee strings that EQ Legends is using for damage logs.