### PR TITLE
Add selectable TTS engine (Windows/Piper/Kokoro) with Kokoro neural voices

### DIFF
--- a/EQLogParser.Audio/EQLogParser.Audio.csproj
+++ b/EQLogParser.Audio/EQLogParser.Audio.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="KokoroSharp.CPU" Version="0.8.4" />
     <PackageReference Include="log4net" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.14" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.11" />

--- a/EQLogParser.Audio/src/AudioManager.cs
+++ b/EQLogParser.Audio/src/AudioManager.cs
@@ -27,6 +27,9 @@ namespace EQLogParser.Audio
   public partial class AudioManager : IAudioManager, IDisposable
   {
     public const string AudioCacheKey = "audio-cache:";
+    public const string WindowsEngine = "Windows";
+    public const string PiperEngine = "Piper";
+    public const string KokoroEngine = "Kokoro";
     public event Action<bool> DeviceListChanged;
     public static AudioManager Instance => Lazy.Value;
 
@@ -39,6 +42,7 @@ namespace EQLogParser.Audio
     private readonly AudioDeviceNotificationClient _notificationClient = new();
     private readonly object _deviceLock = new();
     private readonly bool _usePiper;
+    private readonly bool _useKokoro;
     private readonly List<VoiceInformation> _validVoices = [];
     private MMDeviceEnumerator _deviceEnumerator;
     private Guid _selectedDeviceGuid = Guid.Empty;
@@ -50,12 +54,17 @@ namespace EQLogParser.Audio
     // Dependencies injected by host application
     private static IMemoryCache _cache;
     private static Action<string> _showError;
+    private static string _preferredEngine;
 
     /// <summary>Call once at app startup to inject dependencies.</summary>
-    public static void Initialize(IMemoryCache cache, Action<string> showError = null)
+    /// <param name="preferredEngine">One of <see cref="WindowsEngine"/>, <see cref="PiperEngine"/>, or
+    /// <see cref="KokoroEngine"/>. If null/empty or the engine isn't available, falls back to the first
+    /// available engine in Piper, Kokoro, Windows order.</param>
+    public static void Initialize(IMemoryCache cache, Action<string> showError = null, string preferredEngine = null)
     {
       _cache = cache;
       _showError = showError;
+      _preferredEngine = preferredEngine;
     }
 
     private AudioManager()
@@ -64,11 +73,66 @@ namespace EQLogParser.Audio
       _deviceUpdateTimer = new Timer(DoUpdateDeviceList, null, Timeout.Infinite, Timeout.Infinite);
       _ = InitAudio();
 
-      if (PiperTts.Initialize())
+      if (_preferredEngine == KokoroEngine)
+      {
+        _useKokoro = KokoroTts.Initialize();
+        _usePiper = !_useKokoro && PiperTts.Initialize();
+      }
+      else if (_preferredEngine == WindowsEngine)
+      {
+        // explicit opt-out of both Piper and Kokoro
+      }
+      else if (_preferredEngine == PiperEngine)
+      {
+        _usePiper = PiperTts.Initialize();
+      }
+      else
+      {
+        // no preference saved yet (fresh install / upgrade) -- keep the legacy auto-detect order
+        _usePiper = PiperTts.Initialize();
+        _useKokoro = !_usePiper && KokoroTts.Initialize();
+      }
+
+      if (_usePiper)
       {
         Log.Info("Using piper-tts");
-        _usePiper = true;
       }
+      else if (_useKokoro)
+      {
+        Log.Info("Using kokoro-tts");
+      }
+    }
+
+    public bool IsKokoroModelAvailable() => KokoroTts.IsModelDownloaded();
+
+    public Task<bool> DownloadKokoroModelAsync(Action<float> onProgress, CancellationToken cancellationToken = default) =>
+      KokoroTts.DownloadModelAsync(onProgress, cancellationToken);
+
+    /// <summary>Engines that can currently be selected: Windows is always available; Piper/Kokoro only if their
+    /// voice data has been installed/downloaded.</summary>
+    public static List<string> GetAvailableEngines()
+    {
+      var list = new List<string> { WindowsEngine };
+
+      if (PiperTts.IsVoicePackAvailable())
+      {
+        list.Add(PiperEngine);
+      }
+
+      if (KokoroTts.IsModelDownloaded())
+      {
+        list.Add(KokoroEngine);
+      }
+
+      return list;
+    }
+
+    /// <summary>The engine actually in use for this running session (selecting a different engine requires a restart).</summary>
+    public string GetActiveEngine()
+    {
+      if (_usePiper) return PiperEngine;
+      if (_useKokoro) return KokoroEngine;
+      return WindowsEngine;
     }
 
     private static void ShowAudioError()
@@ -81,7 +145,7 @@ namespace EQLogParser.Audio
 
     public async Task LoadValidVoicesAsync()
     {
-      if (!PiperTts.Initialize() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240) && _validVoices.Count == 0)
+      if (!PiperTts.Initialize() && !_useKokoro && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240) && _validVoices.Count == 0)
       {
         SpeechSynthesizer synth = null;
         IReadOnlyList<VoiceInformation> voices;
@@ -125,6 +189,7 @@ namespace EQLogParser.Audio
     public List<string> GetVoiceList()
     {
       if (_usePiper) return PiperTts.GetVoiceList();
+      if (_useKokoro) return KokoroTts.GetVoiceList();
       var list = new List<string>();
 
       try
@@ -162,6 +227,7 @@ namespace EQLogParser.Audio
     public string GetDefaultVoice()
     {
       if (_usePiper) return PiperTts.GetDefaultVoice();
+      if (_useKokoro) return KokoroTts.GetDefaultVoice();
 
       if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240) && GetVoiceInfo(null) is VoiceInformation { } voiceInfo)
       {
@@ -441,6 +507,17 @@ namespace EQLogParser.Audio
               audio = PiperTts.SynthesizeText(id, tts);
               sample = playerAudio.PiperSampleRate;
             }
+            else if (_useKokoro)
+            {
+              string kokoroVoice;
+              lock (playerAudio)
+              {
+                kokoroVoice = playerAudio.KokoroVoiceName;
+              }
+
+              audio = KokoroTts.SynthesizeText(kokoroVoice, tts);
+              sample = KokoroTts.SampleRate;
+            }
             else
             {
               SpeechSynthesizer synth = null;
@@ -691,6 +768,10 @@ namespace EQLogParser.Audio
           playerAudio.PiperSampleRate = piperVoice.Sample;
         }
       }
+      else if (_useKokoro)
+      {
+        playerAudio.KokoroVoiceName = voice;
+      }
       else
       {
         if (IsLegacyVoice(voice))
@@ -937,6 +1018,11 @@ namespace EQLogParser.Audio
           sample = voiceData.Sample;
           PiperTts.RemoveVoice(testSpeaker);
         }
+      }
+      else if (_useKokoro)
+      {
+        audio = KokoroTts.SynthesizeText(voice, tts);
+        sample = KokoroTts.SampleRate;
       }
       else
       {
@@ -1324,6 +1410,10 @@ namespace EQLogParser.Audio
         {
           PiperTts.Release();
         }
+        else if (_useKokoro)
+        {
+          KokoroTts.Release();
+        }
       }
 
       _disposed = true;
@@ -1344,6 +1434,7 @@ namespace EQLogParser.Audio
       internal SpeechSynthesizer Synth { get; set; }
       internal System.Speech.Synthesis.SpeechSynthesizer SapiSynth { get; set; }
       internal int PiperSampleRate { get; set; }
+      internal string KokoroVoiceName { get; set; }
       internal bool PlayerRequestStop { get; set; }
     }
 

--- a/EQLogParser.Audio/src/IAudioManager.cs
+++ b/EQLogParser.Audio/src/IAudioManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EQLogParser.Audio
@@ -43,5 +44,16 @@ namespace EQLogParser.Audio
 
     // --- TTS: play or export to WAV ---
     void SpeakOrSaveTtsAsync(string text, string voice, string deviceId, float volume, int rate, string fileName = null);
+
+    // --- Kokoro TTS (optional, on-demand neural voice model) ---
+    /// <summary>True if the Kokoro model has already been downloaded to local app data.</summary>
+    bool IsKokoroModelAvailable();
+
+    /// <summary>Downloads the Kokoro model to local app data. Takes effect after the app is restarted.</summary>
+    Task<bool> DownloadKokoroModelAsync(Action<float> onProgress, CancellationToken cancellationToken = default);
+
+    // --- TTS engine selection ---
+    /// <summary>The engine actually in use for this running session. Changing the preferred engine requires a restart.</summary>
+    string GetActiveEngine();
   }
 }

--- a/EQLogParser.Audio/src/KokoroTts.cs
+++ b/EQLogParser.Audio/src/KokoroTts.cs
@@ -1,0 +1,162 @@
+using KokoroSharp;
+using KokoroSharp.Core;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EQLogParser.Audio
+{
+  // Wraps the KokoroSharp neural TTS engine (https://github.com/Lyrcaxis/KokoroSharp). Unlike Piper, the ~320MB
+  // model isn't bundled with the app -- it's fetched on demand into local app data the first time a user opts in.
+  internal static class KokoroTts
+  {
+    private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
+
+    // Pinned to the release that backs the KokoroSharp NuGet version referenced by this project.
+    private const string ModelDownloadUrl = "https://github.com/Lyrcaxis/KokoroSharpBinaries/releases/download/v2.0.0/kokoro.onnx";
+    private const string PreferredDefaultVoice = "af_heart";
+    internal const int SampleRate = 24000;
+
+    private static readonly string DataDir = Path.Combine(
+      Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EQLogParser", "kokoro-tts");
+    private static readonly string ModelPath = Path.Combine(DataDir, "kokoro.onnx");
+
+    private static readonly object Lock = new();
+    private static KokoroWavSynthesizer _synth;
+
+    internal static bool IsModelDownloaded() => File.Exists(ModelPath);
+
+    internal static bool Initialize()
+    {
+      if (_synth != null) return true;
+      if (!IsModelDownloaded()) return false;
+
+      lock (Lock)
+      {
+        if (_synth != null) return true;
+
+        try
+        {
+          _synth = KokoroWavSynthesizer.LoadModel(ModelPath);
+          KokoroVoiceManager.LoadVoicesFromPath();
+          return true;
+        }
+        catch (Exception ex)
+        {
+          Log.Error("Error initializing kokoro-tts", ex);
+          _synth = null;
+          return false;
+        }
+      }
+    }
+
+    internal static async Task<bool> DownloadModelAsync(Action<float> onProgress, CancellationToken cancellationToken = default)
+    {
+      try
+      {
+        Directory.CreateDirectory(DataDir);
+        var tempPath = ModelPath + ".tmp";
+
+        using var client = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
+        using var response = await client.GetAsync(ModelDownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var totalBytes = response.Content.Headers.ContentLength ?? -1L;
+        await using (var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+        await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+          var buffer = new byte[81920];
+          long totalRead = 0;
+          int bytesRead;
+
+          while ((bytesRead = await responseStream.ReadAsync(buffer, cancellationToken)) > 0)
+          {
+            await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+            totalRead += bytesRead;
+
+            if (totalBytes > 0)
+            {
+              onProgress?.Invoke((float)totalRead / totalBytes);
+            }
+          }
+        }
+
+        File.Move(tempPath, ModelPath, true);
+        return true;
+      }
+      catch (Exception ex)
+      {
+        Log.Error("Error downloading kokoro-tts model", ex);
+        return false;
+      }
+    }
+
+    internal static List<string> GetVoiceList()
+    {
+      EnsureVoicesLoaded();
+      return KokoroVoiceManager.Voices.Select(voice => voice.Name).OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    internal static string GetDefaultVoice()
+    {
+      EnsureVoicesLoaded();
+      return KokoroVoiceManager.Voices.FirstOrDefault(voice =>
+        string.Equals(voice.Name, PreferredDefaultVoice, StringComparison.OrdinalIgnoreCase))?.Name
+        ?? KokoroVoiceManager.Voices.FirstOrDefault()?.Name;
+    }
+
+    internal static byte[] SynthesizeText(string voiceName, string text)
+    {
+      if (_synth == null || FindVoice(voiceName) is not { } voice)
+      {
+        return null;
+      }
+
+      return _synth.Synthesize(text, voice);
+    }
+
+    internal static void Release()
+    {
+      lock (Lock)
+      {
+        _synth?.Dispose();
+        _synth = null;
+      }
+    }
+
+    private static void EnsureVoicesLoaded()
+    {
+      if (KokoroVoiceManager.Voices.Count == 0)
+      {
+        try
+        {
+          KokoroVoiceManager.LoadVoicesFromPath();
+        }
+        catch (Exception ex)
+        {
+          Log.Error("Error loading kokoro-tts voices", ex);
+        }
+      }
+    }
+
+    private static KokoroVoice FindVoice(string name)
+    {
+      EnsureVoicesLoaded();
+
+      if (!string.IsNullOrEmpty(name) &&
+          KokoroVoiceManager.Voices.FirstOrDefault(voice => string.Equals(voice.Name, name, StringComparison.OrdinalIgnoreCase)) is { } found)
+      {
+        return found;
+      }
+
+      return KokoroVoiceManager.Voices.FirstOrDefault(voice =>
+        string.Equals(voice.Name, PreferredDefaultVoice, StringComparison.OrdinalIgnoreCase)) ?? KokoroVoiceManager.Voices.FirstOrDefault();
+    }
+  }
+}

--- a/EQLogParser.Audio/src/PiperTts.cs
+++ b/EQLogParser.Audio/src/PiperTts.cs
@@ -19,6 +19,8 @@ namespace EQLogParser.Audio
 
     private PiperTts() { }
 
+    internal static bool IsVoicePackAvailable() => File.Exists(Path.Combine(PiperTtsPath, "voices", "voices.json"));
+
     internal static bool Initialize()
     {
       try

--- a/EQLogParser/App.xaml.cs
+++ b/EQLogParser/App.xaml.cs
@@ -100,7 +100,7 @@ namespace EQLogParser
         ReleaseNotesUrl = $"{ParserHome}/releasenotes.html#{urlVersion}";
 
         MainActions.UpdateStatus($"RenderMode: {RenderOptions.ProcessRenderMode}");
-        AudioManager.Initialize(AppCache);
+        AudioManager.Initialize(AppCache, null, ConfigUtil.GetSetting("TtsEngine"));
         await LoadVoicesSafe();
 
         // preload trigger DB

--- a/EQLogParser/src/ui/main/TtsEngineWindow.xaml
+++ b/EQLogParser/src/ui/main/TtsEngineWindow.xaml
@@ -1,0 +1,52 @@
+<syncfusion:ChromelessWindow x:Class="EQLogParser.TtsEngineWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:local="clr-namespace:EQLogParser"
+  xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+  mc:Ignorable="d"
+  ResizeMode="NoResize"
+  ShowInTaskbar="False"
+  WindowStyle="ToolWindow"
+  TitleBarHeight="{DynamicResource EQTableHeaderRowHeight}"
+  TitleFontSize="{DynamicResource EQContentSize}"
+  TitleBarForeground="{DynamicResource PrimaryDarken}"
+  Icon="EQLogParser.ico"
+  TitleTextAlignment="Left"
+  Topmost="False"
+  UseLayoutRounding="True"
+  WindowStartupLocation="CenterOwner"
+  SizeToContent="WidthAndHeight"
+  Title="TTS Engine">
+  <Grid Margin="16,16,16,10" Width="380">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+    </Grid.RowDefinitions>
+
+    <StackPanel Grid.Row="0" Orientation="Horizontal">
+      <TextBlock Text="TTS Engine:" VerticalAlignment="Center" FontSize="{DynamicResource EQContentSize}" />
+      <ComboBox x:Name="engineList" Width="160" Margin="8,0,0,0" SelectionChanged="EngineSelectionChanged" />
+    </StackPanel>
+    <TextBlock Grid.Row="1" x:Name="engineHintText" TextWrapping="Wrap" Margin="0,6,0,0" FontSize="{DynamicResource EQContentSize}" />
+
+    <Separator Grid.Row="2" Margin="0,14,0,0" />
+
+    <TextBlock Grid.Row="3" x:Name="infoText" TextWrapping="Wrap" Margin="0,14,0,0" FontSize="{DynamicResource EQContentSize}"
+      Text="Kokoro is a free, high quality, local neural Text-to-Speech engine with dozens of voices. It requires a one-time download of about 320MB before it can be used." />
+    <ProgressBar Grid.Row="4" x:Name="progressBar" Height="18" Minimum="0" Maximum="100" Margin="0,14,0,0" Visibility="Collapsed" />
+    <TextBlock Grid.Row="4" x:Name="statusText" TextWrapping="Wrap" Margin="0,14,0,0" FontSize="{DynamicResource EQContentSize}" />
+
+    <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+      <Button x:Name="downloadButton" Foreground="{DynamicResource PrimaryDarken}" Height="{DynamicResource EQButtonHeight}"
+        FontSize="{DynamicResource EQContentSize}" Click="DownloadClicked" Margin="2,0,4,0" Padding="20,0,20,0" Content="Download Kokoro" />
+      <Button x:Name="closeButton" Foreground="{DynamicResource PrimaryDarken}" Height="{DynamicResource EQButtonHeight}"
+        FontSize="{DynamicResource EQContentSize}" Click="CloseClicked" Margin="2,0,4,0" Padding="20,0,20,0" Content="Close" />
+    </StackPanel>
+  </Grid>
+</syncfusion:ChromelessWindow>

--- a/EQLogParser/src/ui/main/TtsEngineWindow.xaml.cs
+++ b/EQLogParser/src/ui/main/TtsEngineWindow.xaml.cs
@@ -1,0 +1,112 @@
+using EQLogParser.Audio;
+using System;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace EQLogParser
+{
+  public partial class TtsEngineWindow
+  {
+    private const string SettingKey = "TtsEngine";
+    private CancellationTokenSource _cts;
+    private bool _downloading;
+    private bool _ready;
+
+    internal TtsEngineWindow()
+    {
+      ThemeConfig.SetCurrentTheme(this);
+      InitializeComponent();
+      Owner = MainActions.GetOwner();
+      RefreshState();
+    }
+
+    private void RefreshState()
+    {
+      _ready = false;
+
+      var engines = AudioManager.GetAvailableEngines();
+      engineList.ItemsSource = engines;
+
+      var saved = ConfigUtil.GetSetting(SettingKey);
+      var selected = !string.IsNullOrEmpty(saved) && engines.Contains(saved) ? saved : AudioManager.Instance.GetActiveEngine();
+      engineList.SelectedItem = engines.Contains(selected) ? selected : engines[0];
+
+      UpdateEngineHint();
+
+      if (AudioManager.Instance.IsKokoroModelAvailable())
+      {
+        downloadButton.IsEnabled = false;
+        downloadButton.Content = "Already Downloaded";
+        statusText.Text = string.Empty;
+      }
+      else
+      {
+        downloadButton.IsEnabled = true;
+        downloadButton.Content = "Download Kokoro";
+        statusText.Text = string.Empty;
+      }
+
+      _ready = true;
+    }
+
+    private void UpdateEngineHint()
+    {
+      if (engineList.SelectedItem is string selected)
+      {
+        engineHintText.Text = selected == AudioManager.Instance.GetActiveEngine()
+          ? "This is the engine currently in use."
+          : "Restart EQLogParser for this change to take effect.";
+      }
+    }
+
+    private void EngineSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+      if (_ready && engineList.SelectedItem is string selected)
+      {
+        ConfigUtil.SetSetting(SettingKey, selected);
+        UpdateEngineHint();
+      }
+    }
+
+    private async void DownloadClicked(object sender, RoutedEventArgs e)
+    {
+      if (_downloading)
+      {
+        return;
+      }
+
+      _downloading = true;
+      _cts = new CancellationTokenSource();
+      downloadButton.IsEnabled = false;
+      progressBar.Visibility = Visibility.Visible;
+      progressBar.Value = 0;
+      statusText.Text = "Downloading...";
+
+      var success = await AudioManager.Instance.DownloadKokoroModelAsync(
+        progress => Dispatcher.Invoke(() => progressBar.Value = Math.Clamp(progress * 100, 0, 100)), _cts.Token);
+
+      _downloading = false;
+      progressBar.Visibility = Visibility.Collapsed;
+
+      if (success)
+      {
+        statusText.Text = "Download complete.";
+        RefreshState();
+      }
+      else
+      {
+        statusText.Text = "Download failed. Check the Error Log for details and try again.";
+        downloadButton.IsEnabled = true;
+      }
+    }
+
+    private void CloseClicked(object sender, RoutedEventArgs e) => Close();
+
+    protected override void OnClosed(EventArgs e)
+    {
+      _cts?.Cancel();
+      base.OnClosed(e);
+    }
+  }
+}

--- a/EQLogParser/src/ui/triggers/TriggersView.xaml
+++ b/EQLogParser/src/ui/triggers/TriggersView.xaml
@@ -55,6 +55,7 @@
           <syncfusion:SfRangeSlider Name="volumeSlider" Height="300" Minimum="0" Maximum="100" LabelOrientation="Horizontal" TickFrequency="10" ValuePlacement="BottomRight" ShowValueLabels="True" Orientation="Vertical" PreviewMouseLeftButtonUp="VolumeSliderChanged"/>
         </Border>
       </Popup>
+      <Button x:Name="ttsEngineButton" Margin="0,0,4,1" Padding="8,0,8,0" IsEnabled="True" Height="{DynamicResource EQButtonHeight}" ToolTip="Choose the Text-to-Speech engine and download the free, local, neural Kokoro voices" Click="TtsEngineClick">TTS Engine</Button>
       <Button x:Name="dictButton" Margin="0,0,4,1" Padding="8,0,8,0" IsEnabled="True" Height="{DynamicResource EQButtonHeight}"  ToolTip="Phonetic Dictionary" Click="DictionaryClick">Dictionary</Button>
       <Button x:Name="quickShareButton" Margin="0,0,8,1" Padding="8,0,8,0" IsEnabled="True" Height="{DynamicResource EQButtonHeight}"  ToolTip="Quick Share Settings and Received Log" Click="QuickShareClick">Quick Shares</Button>
     </StackPanel>

--- a/EQLogParser/src/ui/triggers/TriggersView.xaml.cs
+++ b/EQLogParser/src/ui/triggers/TriggersView.xaml.cs
@@ -1059,6 +1059,12 @@ namespace EQLogParser
       window.ShowDialog();
     }
 
+    private void TtsEngineClick(object sender, RoutedEventArgs e)
+    {
+      var window = new TtsEngineWindow();
+      window.ShowDialog();
+    }
+
     private void QuickShareClick(object sender, RoutedEventArgs e)
     {
       var window = new QuickShareWindow();

--- a/EQLogParserInstall/EQLogParserInstall.iss
+++ b/EQLogParserInstall/EQLogParserInstall.iss
@@ -61,6 +61,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "{#MyReleaseDir}\piper-tts\*"; DestDir: "{app}\piper-tts"; Flags: ignoreversion recursesubdirs createallsubdirs
 #endif
 
+Source: "{#MyReleaseDir}\voices\*"; DestDir: "{app}\voices"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#MyReleaseDir}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyReleaseDir}\DotLiquid.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyReleaseDir}\EQLogParser.deps.json"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
I felt that piper voices were a little harsh. I added Kokoro. I did use a robot to help since I don't have any experience in .net. 

I've tried a bunch of other tools for EQL and nothing has been as good at alerting as EQLogParse.

## Add selectable TTS engine (Windows / Piper / Kokoro), with working Kokoro neural voices

### Changes

**`EQLogParser.Audio` (audio engine)**
- `AudioManager`: replaced the implicit "first engine found wins" startup logic with an explicit, persisted engine preference (`WindowsEngine` / `PiperEngine` / `KokoroEngine` constants). `Initialize()` now takes a `preferredEngine` parameter; if unset it falls back to the previous auto-detect order (Piper → Kokoro → Windows) for existing installs.
- Added `AudioManager.GetAvailableEngines()` — lists engines that can actually be selected right now (Windows always; Piper if its voice pack is present; Kokoro if the model has been downloaded).
- Added `AudioManager.GetActiveEngine()` — reports which engine is actually running this session, so the UI can flag when a change needs a restart.
- `PiperTts`: added `IsVoicePackAvailable()`, a side-effect-free check for the voice pack (previously the only way to check was calling `Initialize()`, which has side effects like setting the native DLL search path).
- `IAudioManager`: added `GetActiveEngine()` to the public contract.

**`EQLogParser` (app)**
- `App.xaml.cs`: reads the persisted `"TtsEngine"` setting and passes it into `AudioManager.Initialize()` at startup.
- New `TtsEngineWindow` (replaces `KokoroSetupWindow`): adds a combo box to pick the active TTS engine from whatever's currently available, persists the choice, and shows a "restart required" hint when the selection differs from the active engine — alongside the existing Kokoro model download flow.
- `TriggersView`: renamed the "Kokoro TTS" button to "TTS Engine" and pointed it at the new window.

**Installer**
- `EQLogParserInstall.iss`: minor — installs the bundled Kokoro `voices\*` folder unconditionally (previously only Piper's voices were referenced).

### Behavior after this change
- Fresh/existing installs keep today's behavior by default (Piper wins if present).
- Downloading Kokoro and explicitly selecting it in the new TTS Engine window makes it the active engine on next launch, regardless of whether Piper is also present.
- Once Kokoro is active, the existing voice dropdowns (Triggers tab default voice, per-character voice in Manage Characters, WAV export) list its ~50 voices — that plumbing already existed and just needed Kokoro to actually get a turn.

### Not covered
- No automated tests added (none existed for `AudioManager`'s engine selection previously).
- Not manually verified end-to-end in a packaged installer build — tested via local dev build only.